### PR TITLE
[Bug] add answers for anonymous users and fix some integrity problems

### DIFF
--- a/server/api/question/views.py
+++ b/server/api/question/views.py
@@ -21,11 +21,12 @@ class QuestionViewSet(viewsets.ModelViewSet):
         search_fields (list): The fields to search in the viewset.
         filterset_fields (list): The fields to filter in the viewset.
     """
-    queryset = Question.objects.all()
+    queryset = Question.objects.all().order_by("-time_created")
     serializer_class = QuestionSerializer
     filter_backends = [DjangoFilterBackend, filters.SearchFilter]
     search_fields = ['name']
     filterset_fields = ['mark', 'answers__value']
+    ordering_fields = ['time_created', 'time_modified', 'diff_level', 'mark']
 
     # override the create method
     def create(self, request, *args, **kwargs):

--- a/server/api/question/views.py
+++ b/server/api/question/views.py
@@ -23,7 +23,7 @@ class QuestionViewSet(viewsets.ModelViewSet):
     """
     queryset = Question.objects.all().order_by("-time_created")
     serializer_class = QuestionSerializer
-    filter_backends = [DjangoFilterBackend, filters.SearchFilter]
+    filter_backends = [DjangoFilterBackend, filters.SearchFilter, filters.OrderingFilter]
     search_fields = ['name']
     filterset_fields = ['mark', 'answers__value']
     ordering_fields = ['time_created', 'time_modified', 'diff_level', 'mark']

--- a/server/api/quiz/models.py
+++ b/server/api/quiz/models.py
@@ -131,6 +131,8 @@ class QuizAttempt(models.Model):
         if not is_available:
             self.state = QuizAttempt.State.COMPLETED
             self.save()
+        elif self.state == QuizAttempt.State.SUBMITTED:
+            return False
         else:
             self.state = QuizAttempt.State.IN_PROGRESS
             self.save()

--- a/server/api/quiz/serializers.py
+++ b/server/api/quiz/serializers.py
@@ -1,9 +1,13 @@
 from rest_framework import serializers
 from api.question.models import Question, Category
+from api.question.serializers import AnswerSerializer
 from api.quiz.models import Quiz, QuizSlot, QuizAttempt, QuestionAttempt
 
 
 class QuestionSerializer(serializers.ModelSerializer):
+    # answers is a foreign key field, so we need to use a nested serializer
+    answers = AnswerSerializer(many=True)
+
     class Meta:
         model = Question
         fields = '__all__'

--- a/server/api/quiz/urls.py
+++ b/server/api/quiz/urls.py
@@ -1,10 +1,10 @@
 from rest_framework.routers import DefaultRouter
-from .views import QuizViewSet, QuizSlotViewSet, QuizAttemptViewSet, QuestionAttemptViewSet, AdminQuizViewSet, CompetistionQuizViewSet
+from .views import QuizViewSet, QuizSlotViewSet, QuizAttemptViewSet, QuestionAttemptViewSet, AdminQuizViewSet, CompetitionQuizViewSet
 
 router = DefaultRouter()
 router.register(r'admin-quizzes', AdminQuizViewSet, basename='')
 router.register(r'all_quizzes', QuizViewSet)
-router.register(r'competition', CompetistionQuizViewSet, basename='competition')
+router.register(r'competition', CompetitionQuizViewSet, basename='competition')
 router.register(r'quiz-slots', QuizSlotViewSet)
 router.register(r'quiz-attempts', QuizAttemptViewSet)
 router.register(r'question-attempts', QuestionAttemptViewSet)

--- a/server/api/quiz/views.py
+++ b/server/api/quiz/views.py
@@ -137,15 +137,15 @@ class QuizViewSet(viewsets.ReadOnlyModelViewSet):
             return Response({'error': 'Quiz not exist'}, status=status.HTTP_404_NOT_FOUND)
         if quiz.visible and quiz.status == 0:
             self.serializer_class = QuizSlotSerializer
-            instance = QuizSlot.objects.filter(quiz_id=pk)
-            serializer = QuizSlotSerializer(instance, many=True)
+            instances = QuizSlot.objects.filter(quiz_id=pk)
+            serializer = QuizSlotSerializer(instances, many=True)
             return Response(serializer.data)
         else:
             return Response({'error': 'Quiz not exist'}, status=status.HTTP_404_NOT_FOUND)
 
 
 @permission_classes([IsAuthenticated])
-class CompetistionQuizViewSet(viewsets.ReadOnlyModelViewSet):
+class CompetitionQuizViewSet(viewsets.ReadOnlyModelViewSet):
     """
     A viewset for retrieving competition quizzes that are visible and have a status of 1.
     Need to be tested.
@@ -155,6 +155,18 @@ class CompetistionQuizViewSet(viewsets.ReadOnlyModelViewSet):
     """
     queryset = Quiz.objects.filter(status=1, visible=True)
     serializer_class = UserQuizSerializer
+
+    @action(detail=True, methods=['get'])
+    def submit(self, request, pk=None):
+        """
+        Submit the quiz attempt, changing its state to 2 (submitted).
+        """
+        user = request.user.student
+        attempt = user.quiz_attempts.get(quiz_id=pk)
+        attempt.state = QuizAttempt.State.SUBMITTED
+        attempt.time_finish = now()
+        attempt.save()
+        return Response({'status': 'Quiz attempt submitted successfully.'})
 
     @action(detail=True, methods=['get'])
     def slots(self, request, pk=None):
@@ -193,6 +205,11 @@ class CompetistionQuizViewSet(viewsets.ReadOnlyModelViewSet):
             quiz_id=pk, student_id=student_id).first()
         # if attempt after the quiz has finished:
         is_available = self._is_available(quiz_instance, existing_attempt)
+
+        user = request.user.student
+        if existing_attempt is not None and user.quiz_attempts.get(pk=pk).state == QuizAttempt.State.SUBMITTED:
+            return Response({'error': 'Quiz has submitted '}, status=status.HTTP_400_BAD_REQUEST)
+
         if quiz_instance.status == 3 and existing_attempt is None:
             return Response({'error': 'Quiz has finished'}, status=status.HTTP_404_NOT_FOUND)
         # check the attemt is available or not
@@ -256,10 +273,12 @@ class CompetistionQuizViewSet(viewsets.ReadOnlyModelViewSet):
             quiz_attempt_serializer = QuizAttemptSerializer(data={
                 'quiz': quiz_id,
                 'student': user.student.id,
-                'state': 2,
+                'state': QuizAttempt.State.IN_PROGRESS,
             })
             quiz_attempt_serializer.is_valid(raise_exception=True)
             attempt = quiz_attempt_serializer.save()
+
+            # run attempt.is_available to update the dead_line
             attempt.is_available
             end_time = attempt.dead_line
         else:
@@ -312,13 +331,12 @@ class QuizAttemptViewSet(viewsets.ModelViewSet):
         student_id = request.data.get('student')
         existing_attempt = QuizAttempt.objects.filter(
             quiz_id=quiz_id, student_id=student_id).first()
-        print(existing_attempt)
 
         if existing_attempt:
             serializer = self.get_serializer(existing_attempt)
             data = serializer.data
             if not data.is_available:
-                return Response({'error': 'Quiz has finished3'}, status=status.HTTP_403_FORBIDDEN)
+                return Response({'error': 'Quiz has finished'}, status=status.HTTP_403_FORBIDDEN)
 
             # switch cases by state
             match existing_attempt.state:
@@ -337,9 +355,9 @@ class QuizAttemptViewSet(viewsets.ModelViewSet):
     def update(self, request, *args, **kwargs):
         instance = self.get_object()
         match instance.state:
-            case 2:
+            case QuizAttempt.State.IN_PROGRESS:
                 data = request.data.copy()
-                if int(data.get('state')) == 3:
+                if int(data.get('state')) == QuizAttempt.State.SUBMITTED:
                     # set the time_finish to the current time
                     data['time_finish'] = now()
 
@@ -349,24 +367,21 @@ class QuizAttemptViewSet(viewsets.ModelViewSet):
 
                 return Response(serializer.data, status=status.HTTP_200_OK)
 
-            case 3:
+            case QuizAttempt.State.SUBMITTED:
                 return Response({'error': 'You have already submitted this quiz.'}, status=status.HTTP_403_FORBIDDEN)
-            case 4:
+            case QuizAttempt.State.COMPLETED:
                 return Response({'error': 'The competition has ended.'}, status=status.HTTP_403_FORBIDDEN)
 
-        # if existing_attempt.state == 2:
-        #     existing_attempt.state = 0
-        #     existing_attempt.save()
-        # existing_attempt.save()
-        # return Response({'message': 'Answer updated successfully.'}, status=status.HTTP_200_OK)
-
-        return super().create(request, *args, **kwargs)
+        return super().update(request, *args, **kwargs)
 
     @action(detail=True, methods=['get'])
     def submit(self, request, pk=None):
         """
         Submit the quiz attempt, changing its state to 2 (submitted).
         """
+        user = request.user
+        if self.student != user.student:
+            return Response({'error': 'You are not authorized to perform this action.'}, status=status.HTTP_403_FORBIDDEN)
         attempt = self.get_object()
         attempt.state = QuizAttempt.State.SUBMITTED
         attempt.time_finish = now()

--- a/server/api/users/views.py
+++ b/server/api/users/views.py
@@ -115,7 +115,6 @@ class TeacherViewSet(viewsets.ModelViewSet):
         if request.user.is_staff:
             return super().retrieve(request, *args, **kwargs)
         elif hasattr(request.user, "teacher"):
-            print(kwargs["pk"])
             if request.user.teacher.id == int(kwargs["pk"]):
                 return super().retrieve(request, *args, **kwargs)
             else:


### PR DESCRIPTION
1. fix typos
2. order questions by creation time
3. add a nested serializer for answers of each question
4. implement new competition submission
5. update state management logic.

### Improvements to quiz and question functionalities:

* [`server/api/question/views.py`](diffhunk://#diff-a19c7dbddd159e169da8ae9440ec47726874d9e15661d5cd057de15f1962ade8L24-R29): Ordered the `Question` queryset by `time_created` and added `ordering_fields` for better query management.

* [`server/api/quiz/views.py`](diffhunk://#diff-147365969c4ed40935035d06b6957e05ee88d29731ea258ade36c8168a187594R159-R170): Implemented new logic to handle quiz submission and state management, including the addition of a `submit` action in the `CompetitionQuizViewSet` and various state checks in the `create` and `update` methods. [[1]](diffhunk://#diff-147365969c4ed40935035d06b6957e05ee88d29731ea258ade36c8168a187594R159-R170) [[2]](diffhunk://#diff-147365969c4ed40935035d06b6957e05ee88d29731ea258ade36c8168a187594L340-R360) [[3]](diffhunk://#diff-147365969c4ed40935035d06b6957e05ee88d29731ea258ade36c8168a187594L352-R384)

### Data serialization enhancements:

* [`server/api/quiz/serializers.py`](diffhunk://#diff-c07a531095d8fe6afc61e492daf98b1cd28adb3b00b365d692d00a6bed932b15R3-R10): Added a nested serializer for the `answers` field in the `QuestionSerializer` to properly serialize related answer data.

### Typo fixes:

* `server/api/quiz/urls.py` and `server/api/quiz/views.py`: Corrected the typo in `CompetistionQuizViewSet` to `CompetitionQuizViewSet` for consistency and accuracy. [[1]](diffhunk://#diff-64e03941666b940aad52720b029d91503f639782fa36782e54c1cc29cc79fe02L2-R7) [[2]](diffhunk://#diff-147365969c4ed40935035d06b6957e05ee88d29731ea258ade36c8168a187594L140-R148)

### Additional improvements:

* [`server/api/quiz/models.py`](diffhunk://#diff-370c744fa0e045deec1747703a401274a101acf24419bbddb32bd305ec4eaf16R134-R135): Added a state check in the `is_available` method to ensure that a quiz cannot be marked as available if it is already submitted.

These changes collectively enhance the functionality, maintainability, and readability of the codebase.