### PR TITLE
Update production settings and adjust Gunicorn worker count

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -23,7 +23,7 @@ services:
       - ./opt/accesslogs/:/var/log/accesslogs/
       - ./opt/static_files:/opt/static_files
     environment:
-      - DJANGO_SETTINGS_MODULE=wajo.settings
+      - DJANGO_SETTINGS_MODULE=api.settings
     depends_on:
       - db
 

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -42,6 +42,6 @@ if [ "${APP_ENV^^}" = "PRODUCTION" ]; then
 
     # Run Gunicorn / Django
     printf "\n" && echo " Running Gunicorn / Django"
-    echo "Running: gunicorn api.wsgi -b 0.0.0.0:8081 --workers=6 --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50"
-    gunicorn api.wsgi -b 0.0.0.0:8081 --workers=6 --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50
+    echo "Running: gunicorn api.wsgi -b 0.0.0.0:8081 --workers=1 --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50"
+    gunicorn api.wsgi -b 0.0.0.0:8081 --workers=1 --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50
 fi

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Coders for Causes"]
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.12"


### PR DESCRIPTION
Adjust the Django settings module for production and reduce the Gunicorn worker count to optimize resource usage. Additionally, update the package mode in the configuration.