### PR TITLE
Set dynamic env variables for Gunicorn workers and port in Docker entrypoint script

### DIFF
--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -40,8 +40,18 @@ fi
 # ===================
 if [ "${APP_ENV^^}" = "PRODUCTION" ]; then
 
+    # if the number of workers is not set, default to 1
+    if [ -z "${GUNICORN_WORKERS}" ]; then
+        GUNICORN_WORKERS=3
+    fi
+
+    # if the port is not set, default to 8081
+    if [ -z "${GUNICORN_PORT}" ]; then
+        GUNICORN_PORT=8081
+    fi
+
     # Run Gunicorn / Django
     printf "\n" && echo " Running Gunicorn / Django"
-    echo "Running: gunicorn api.wsgi -b 0.0.0.0:8081 --workers=1 --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50"
-    gunicorn api.wsgi -b 0.0.0.0:8081 --workers=1 --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50
+    echo "Running: gunicorn api.wsgi -b 0.0.0.0:$GUNICORN_PORT --workers=$GUNICORN_WORKERS --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50"
+    gunicorn api.wsgi -b 0.0.0.0:"$GUNICORN_PORT" --workers="$GUNICORN_WORKERS" --keep-alive 20 --log-file=- --log-level debug --access-logfile=/var/log/accesslogs/gunicorn --capture-output --timeout 50
 fi

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -40,7 +40,7 @@ fi
 # ===================
 if [ "${APP_ENV^^}" = "PRODUCTION" ]; then
 
-    # if the number of workers is not set, default to 1
+    # if the number of workers is not set, default to 3
     if [ -z "${GUNICORN_WORKERS}" ]; then
         GUNICORN_WORKERS=3
     fi

--- a/server/.env.example
+++ b/server/.env.example
@@ -5,6 +5,7 @@ API_SECRET_KEY="supersecretkey"
 API_ALLOWED_HOSTS=".localhost 127.0.0.1 [::1]"
 API_CORS_ALLOWED_ORIGINS="http://localhost:3000 https://localhost:3000"
 
+# need to set POSTGRES_HOST to the name of the container in docker-compose when using docker on production
 POSTGRES_HOST=localhost
 POSTGRES_NAME=postgres
 POSTGRES_USER=postgres
@@ -14,5 +15,9 @@ POSTGRES_PORT=5432
 DJANGO_SUPERUSER_PASSWORD=Password123
 DJANGO_SUPERUSER_EMAIL=admin@test.com
 DJANGO_SUPERUSER_USERNAME=admin
+
+# production
+GUNICORN_WORKERS=3
+GUNICORN_PORT=8081
 
 FRONTEND_URL="http://localhost:3000"


### PR DESCRIPTION
- Configure dynamic env variables and its default values for Gunicorn workers and port in the entrypoint script to enhance production readiness.
- Add comment in `env.example` file to make it clearer

# Related issue

- Resolve #165