### PR TITLE
Issue 204 fix quiz submission bug

### DIFF
--- a/client/src/components/layout.tsx
+++ b/client/src/components/layout.tsx
@@ -64,12 +64,7 @@ export function ProtectedPage({ children, requiredRoles }: ProtectedPageProps) {
       );
     case "authorized":
       return (
-        <Sidebar
-          role={userRole.toLowerCase() as Role}
-          isShowBreadcrumb={userRole !== Role.STUDENT}
-        >
-          {children}
-        </Sidebar>
+        <Sidebar role={userRole.toLowerCase() as Role}>{children}</Sidebar>
       );
     default:
       return <WaitingLoader />;

--- a/client/src/components/ui/Quiz/comp-start.tsx
+++ b/client/src/components/ui/Quiz/comp-start.tsx
@@ -182,8 +182,7 @@ export function CompStart({
           });
         window.alert("Your answers have been submitted successfully.");
         // refresh the page to get the latest data
-        window.location.reload();
-        router.push("/");
+        window.location.href = "/quiz";
       }
       console.log("Final answers:", userAnswers);
     }

--- a/client/src/components/ui/Quiz/quiz-intro.tsx
+++ b/client/src/components/ui/Quiz/quiz-intro.tsx
@@ -5,18 +5,24 @@ interface Props {
   onStart: () => void;
   quizName: string;
   startTime: string | Date;
+  timeWindow: number;
   quizDuration: number;
   numberOfQuestions: number;
-  isFinished?: boolean;
+  isFinished: boolean;
+  isEntryClosed: boolean;
+  isSubmitted: boolean;
 }
 
 export default function QuizIntro({
   onStart,
   quizName,
   startTime,
+  timeWindow,
   quizDuration,
   numberOfQuestions,
   isFinished,
+  isEntryClosed,
+  isSubmitted,
 }: Partial<Props>) {
   let headingStyle = `text-xl sm:text-2xl md:text-3xl text-slate-800 font-bold`;
   let generalInstructions =
@@ -36,6 +42,9 @@ export default function QuizIntro({
             className="flex-row gap-1 font-bold"
           />
         </div>
+        <div className="my-4 flex gap-2">
+          Competition will allow entering within {timeWindow} minutes
+        </div>
         <div className="mb-2 flex items-center justify-between">
           <h2 className={headingStyle}>Individual Quiz</h2>
           <h2 className={headingStyle}>{quizDuration} minutes</h2>
@@ -53,6 +62,14 @@ export default function QuizIntro({
         {isFinished ? (
           <Button size="lg" variant={"inactive"}>
             Competition has finished
+          </Button>
+        ) : isEntryClosed ? (
+          <Button size="lg" variant={"inactive"}>
+            Entries for the competition are now closed
+          </Button>
+        ) : isSubmitted ? (
+          <Button size="lg" variant={"inactive"}>
+            You have submitted your answer
           </Button>
         ) : (
           <Button size="lg" onClick={onStart}>

--- a/client/src/components/ui/Quiz/quiz-intro.tsx
+++ b/client/src/components/ui/Quiz/quiz-intro.tsx
@@ -7,6 +7,7 @@ interface Props {
   startTime: string | Date;
   quizDuration: number;
   numberOfQuestions: number;
+  isFinished?: boolean;
 }
 
 export default function QuizIntro({
@@ -15,6 +16,7 @@ export default function QuizIntro({
   startTime,
   quizDuration,
   numberOfQuestions,
+  isFinished,
 }: Partial<Props>) {
   let headingStyle = `text-xl sm:text-2xl md:text-3xl text-slate-800 font-bold`;
   let generalInstructions =
@@ -48,9 +50,15 @@ export default function QuizIntro({
           <span className="font-bold"> not </span> be expected to be to scale.
         </p>
         <div className="h-4 w-full"></div>
-        <Button size="lg" onClick={onStart}>
-          Start
-        </Button>
+        {isFinished ? (
+          <Button size="lg" variant={"inactive"}>
+            Competition has finished
+          </Button>
+        ) : (
+          <Button size="lg" onClick={onStart}>
+            Start
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/client/src/components/ui/mobilenav.tsx
+++ b/client/src/components/ui/mobilenav.tsx
@@ -1,12 +1,16 @@
 import { AlignJustify, X } from "lucide-react";
 import Image from "next/image";
 import Link from "next/link";
+import { useRouter } from "next/router";
 import { Drawer } from "vaul";
 
 import { Button } from "@/components/ui/button";
 import { LoginModal } from "@/components/ui/Users/login-modal";
+import { useAuth } from "@/context/auth-provider";
 
 export default function MobileNav() {
+  const router = useRouter();
+  const { isLoggedIn } = useAuth();
   return (
     <Drawer.Root direction="top">
       <Drawer.Trigger className="relative flex h-10 flex-shrink-0 items-center justify-center gap-2 overflow-hidden rounded-full bg-white px-4 text-sm font-medium shadow-sm transition-all hover:bg-[#FAFAFA] dark:bg-[#161615] dark:text-white dark:hover:bg-[#1A1A19]">
@@ -42,15 +46,26 @@ export default function MobileNav() {
               <Link href="/awards">Awards</Link>
               <Link href="/quiz">Quizzes</Link>
               <Link href="/contact">Contact us</Link>
-              <LoginModal>
+              {isLoggedIn ? (
                 <Button
                   variant={"outline"}
                   size={"lg"}
                   className="border-2 border-black font-roboto text-lg"
+                  onClick={() => router.push("/dashboard")}
                 >
-                  Login
+                  Dashboard
                 </Button>
-              </LoginModal>
+              ) : (
+                <LoginModal>
+                  <Button
+                    variant={"outline"}
+                    size={"lg"}
+                    className="border-2 border-black font-roboto text-lg"
+                  >
+                    Login
+                  </Button>
+                </LoginModal>
+              )}
             </Drawer.Description>
             {/* </div> */}
           </div>

--- a/client/src/pages/quiz/competition/[id].tsx
+++ b/client/src/pages/quiz/competition/[id].tsx
@@ -24,6 +24,7 @@ export default function CompetitionQuizPage() {
   const router = useRouter();
   const compId = router.query.id as string;
   const [start, setStart] = useState(false);
+  const [isFinished, setIsFinished] = useState(false);
   const handleStart = () => {
     setStart(true);
     // console.log(compId);
@@ -40,6 +41,17 @@ export default function CompetitionQuizPage() {
     enabled: !!compId, // Only run the query if compId is defined
   });
 
+  useEffect(() => {
+    if (compData) {
+      const endTime = new Date(compData.open_time_date);
+      endTime.setMinutes(endTime.getMinutes() + compData.time_limit);
+      const now = new Date();
+      if (now > endTime) {
+        setIsFinished(true);
+      }
+    }
+  }, [compData]);
+
   if (!compId) return <WaitingLoader />;
 
   console.log(compId);
@@ -51,6 +63,7 @@ export default function CompetitionQuizPage() {
           quizDuration: compData?.time_limit,
           startTime: compData?.open_time_date,
           onStart: handleStart,
+          isFinished: isFinished,
         }}
       />
     );

--- a/client/src/pages/quiz/index.tsx
+++ b/client/src/pages/quiz/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Cookies from "js-cookie";
 import { createContext, useContext, useEffect } from "react";
 
 import { PublicPage } from "@/components/layout";
@@ -41,22 +42,24 @@ const QuizPage = () => {
     endpoint: "/quiz/competition/",
   });
 
+  const userRole = Cookies.get("user_role");
   if (isQuizDataLoading || !quizData || isCompQuizDataLoading || !compQuizData)
     return <WaitingLoader />;
   if (isQuizDataError) return <div>Error Quiz: {QuizDataError?.message}</div>;
-  if (isCompQuizDataError)
+  if (userRole && isCompQuizDataError)
     return <div>Error Competition: {compQuizDataError?.message}</div>;
 
   return (
     <div className="md:grid-cols mx-1 my-20 mt-10 grid auto-rows-min gap-4">
-      {compQuizData.results.length > 0 ? (
-        <CompetitionCard
-          className="mx-auto w-full max-w-lg"
-          {...compQuizData}
-        />
-      ) : (
-        <NoCompetitionCard className="mx-auto w-full max-w-lg" />
-      )}
+      {userRole &&
+        (compQuizData.results.length > 0 ? (
+          <CompetitionCard
+            className="mx-auto w-full max-w-lg"
+            {...compQuizData}
+          />
+        ) : (
+          <NoCompetitionCard className="mx-auto w-full max-w-lg" />
+        ))}
       <PracticeCard className="mx-auto w-full max-w-lg" {...quizData} />
     </div>
   );

--- a/client/src/pages/team/submit-success.tsx
+++ b/client/src/pages/team/submit-success.tsx
@@ -1,0 +1,13 @@
+import { useRouter } from "next/router";
+
+import { Button } from "@/components/ui/button";
+
+export default function SubmitSuccess() {
+  const router = useRouter();
+  return (
+    <>
+      <div>Team submission completed!</div>
+      <Button onClick={() => router.push("/team")}>Back</Button>
+    </>
+  );
+}

--- a/client/src/types/quiz.ts
+++ b/client/src/types/quiz.ts
@@ -163,8 +163,10 @@ export interface QuizAttempt {
   time_finish: Date;
   time_modified: Date;
   total_marks: number;
+  dead_line: Date;
   quiz: number;
   student: number;
+  student_user_id: number;
   team: number;
 }
 

--- a/server/api/quiz/models.py
+++ b/server/api/quiz/models.py
@@ -19,6 +19,7 @@ class Quiz(models.Model):
        visible (BooleanField): Notes whether the quiz is visible.
        open_time_date (DateTimeField): Notes when the quiz opens.
        time_limit (Integer): Denotes the time allotted for each quiz.
+       time_window: The amount of time after quiz start that a student has to be able to start the quiz
     """
 
     id = models.AutoField(primary_key=True)
@@ -42,9 +43,11 @@ class Quiz(models.Model):
     def clean(self):
         if self.is_comp:
             if self.open_time_date is None:
-                raise ValidationError({'open_time_date': 'This field is required for competition quizzes.'})
+                raise ValidationError(
+                    {'open_time_date': 'This field is required for competition quizzes.'})
             if self.time_window is None:
-                raise ValidationError({'time_window': 'This field is required for competition quizzes.'})
+                raise ValidationError(
+                    {'time_window': 'This field is required for competition quizzes.'})
         super().clean()
 
     def save(self, *args, **kwargs):
@@ -64,7 +67,8 @@ class QuizSlot(models.Model):
     """
 
     id = models.AutoField(primary_key=True)
-    quiz = models.ForeignKey(Quiz, on_delete=models.CASCADE, related_name="quiz_slots")
+    quiz = models.ForeignKey(
+        Quiz, on_delete=models.CASCADE, related_name="quiz_slots")
     question = models.ForeignKey(
         Question, on_delete=models.CASCADE, default=None, related_name="slots"
     )
@@ -99,7 +103,8 @@ class QuizAttempt(models.Model):
         COMPLETED = 4
 
     id = models.AutoField(primary_key=True)
-    quiz = models.ForeignKey(Quiz, on_delete=models.CASCADE, related_name="attempts")
+    quiz = models.ForeignKey(
+        Quiz, on_delete=models.CASCADE, related_name="attempts")
     student = models.ForeignKey(
         Student,
         on_delete=models.CASCADE,
@@ -108,7 +113,8 @@ class QuizAttempt(models.Model):
         null=True,
     )
     current_page = models.IntegerField()
-    state = models.IntegerField(choices=State.choices, default=State.UNATTEMPTED)
+    state = models.IntegerField(
+        choices=State.choices, default=State.UNATTEMPTED)
     time_start = models.DateTimeField(auto_now_add=True)
     time_finish = models.DateTimeField(null=True, blank=True)
     time_modified = models.DateTimeField(auto_now=True)

--- a/server/api/quiz/serializers.py
+++ b/server/api/quiz/serializers.py
@@ -41,7 +41,8 @@ class QuizSlotSerializer(serializers.ModelSerializer):
         required=True,
         allow_null=True,
     )
-    slot_index = serializers.IntegerField(required=True, min_value=0, max_value=99)
+    slot_index = serializers.IntegerField(
+        required=True, min_value=0, max_value=99)
     quiz_id = serializers.PrimaryKeyRelatedField(
         queryset=Quiz.objects.all(),
         write_only=True,
@@ -55,7 +56,8 @@ class QuizSlotSerializer(serializers.ModelSerializer):
         quiz = data["quiz"]
         slot_index = data["slot_index"]
         if QuizSlot.objects.filter(quiz=quiz, slot_index=slot_index).exists():
-            raise serializers.ValidationError("Slot index already exists for this quiz")
+            raise serializers.ValidationError(
+                "Slot index already exists for this quiz")
         return data
 
     class Meta:
@@ -100,6 +102,8 @@ class AdminQuizSerializer(serializers.ModelSerializer):
 class QuizAttemptSerializer(serializers.ModelSerializer):
     current_page = serializers.IntegerField(default=0, required=False)
     total_marks = serializers.IntegerField(default=0, required=False)
+    student_user_id = serializers.IntegerField(
+        source='student.user.id', read_only=True)
 
     class Meta:
         model = QuizAttempt

--- a/server/api/quiz/urls.py
+++ b/server/api/quiz/urls.py
@@ -9,8 +9,8 @@ from .views import (
 )
 
 router = DefaultRouter()
-router.register(r"admin-quizzes", AdminQuizViewSet, basename="")
-router.register(r"all-quizzes", QuizViewSet)
+router.register(r"admin-quizzes", AdminQuizViewSet, basename="")  # all quizzes
+router.register(r"all-quizzes", QuizViewSet)     # all visible quizzes
 router.register(r"competition", CompetitionQuizViewSet, basename="competition")
 router.register(r"quiz-slots", QuizSlotViewSet)
 router.register(r"quiz-attempts", QuizAttemptViewSet)

--- a/server/api/quiz/views.py
+++ b/server/api/quiz/views.py
@@ -92,7 +92,8 @@ class AdminQuizViewSet(viewsets.ModelViewSet):
                 quiz = Quiz.objects.get(pk=pk)
                 quiz_slots = quiz.quiz_slots.all()
                 questions = [slot.question for slot in quiz_slots]
-                quiz.total_marks = sum([question.mark for question in questions])
+                quiz.total_marks = sum(
+                    [question.mark for question in questions])
                 quiz.save()
 
                 return Response(serializer.data, status=status.HTTP_201_CREATED)
@@ -197,7 +198,7 @@ class CompetitionQuizViewSet(viewsets.ReadOnlyModelViewSet):
     """
 
     queryset = Quiz.objects.filter(
-        status=1, visible=True).order_by("-created_at")
+        status=1, visible=True, is_comp=True).order_by("-created_at")
     serializer_class = UserQuizSerializer
 
     def get_permissions(self):
@@ -443,8 +444,10 @@ class QuizAttemptViewSet(viewsets.ModelViewSet):
         print("request.user: ", request.user)
         print("request.user.student: ", request.user.student)
         print("request.user.student.id: ", request.user.student.id)
-        print("request.user.student.quiz_attempts: ", request.user.student.quiz_attempts)
-        print("request.user.student.quiz_attempts.all(): ", request.user.student.quiz_attempts.all())
+        print("request.user.student.quiz_attempts: ",
+              request.user.student.quiz_attempts)
+        print("request.user.student.quiz_attempts.all(): ",
+              request.user.student.quiz_attempts.all())
         print("-----------------------------------------")
         print("-----------------------------------------\n\n")
         quiz_id = request.data.get("quiz")
@@ -504,7 +507,8 @@ class QuizAttemptViewSet(viewsets.ModelViewSet):
             # return super().create(request, *args, **kwargs)
             # Create a new QuizAttempt and assign the team
             data = request.data.copy()
-            data["team"] = team.id if team else None  # Assign the team ID or None if no team is found
+            # Assign the team ID or None if no team is found
+            data["team"] = team.id if team else None
             serializer = self.get_serializer(data=data)
             serializer.is_valid(raise_exception=True)
             self.perform_create(serializer)


### PR DESCRIPTION
## Change Summary
**[Briefly summarise the changes that you made. Just high-level stuff]**
Fixed some bugs:
- after a comp is submitted the user should be redirected to `/quiz` not `/quiz/[id]`
    - does the restart un-submit the quiz attempt? **No**
    - does the restart create another quiz attempt when you click start? **No**
    - how does the restart affect the quiz-attempts page in dashboard/results/[id]/quiz-attempts/? **Won't affect anything bc it's not a restart, the server will not allow a second attempt for the same comp**
-  student view sidebar didn't show
-  quiz app `view.py` didn't filter competition properly.
- the mobile view navbar shows `login` instead of `dashboard`.
- visitors can access competition.
- when a comp has already finished, you can still start the quiz
- Once a student submitted a comp, can still start the comp (will get 400 from server)
-  couldn't get matching user id from student model

### Change Form
**Fill this up (NA if not available). If a certain criteria is not met, can you please give a reason.**

- [x] The pull request title has an issue number
- [ ] The change works by "Smoke testing" or quick testing
- [ ] The change has tests
- [ ] The change has documentation

## Other Information
**[Is there anything in particular in the review that I should be aware of?]**
Still needs to be done:
- quiz model `status` field is very hard to understand. Considering replace it with filtering date `is_comp` and `visible` field
- didn't have attempts in the sidebar for students. It seems we haven't implemented this feature
- when the question is the last one in a practice quiz, this `next` button should change to `submit`
- answer is auto filled for same question in comp. Will it only store one attempt for each question?
- TODOs in comp components

# Related issue

- Resolve #204